### PR TITLE
feat: translate non-English HR blurbs for executive recruitment

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -4,7 +4,7 @@
   "version": "0.17.3",
   "description": "Various quality of life improvements for Sim Companies players.",
   "permissions": ["storage"],
-  "host_permissions": ["https://api.github.com/*", "https://github.com/*"],
+  "host_permissions": ["https://api.github.com/*", "https://github.com/*", "https://lingva.ml/*", "https://lingva.thedaviddelta.com/*"],
   "background": {
     "service_worker": "background.js",
     "type": "module"

--- a/src/executive_ui.js
+++ b/src/executive_ui.js
@@ -6,12 +6,14 @@
 
 import { stringSimilarity } from "string-similarity-js";
 import hrBlurpData from "./resources/hr_blurp.json";
-import { t } from "./i18n.js";
+import { t, getLang } from "./i18n.js";
 import { getSectionContent } from "./sidebar.js";
 import { escapeHtml } from "./utils.js";
+import { translateToEnglish } from "./translate.js";
 
 const SECTION_ID = "executive-section";
 const SIMILARITY_THRESHOLD = 0.7;
+const TRANSLATED_SIMILARITY_THRESHOLD = 0.55;
 const SKILL_KEYS = ["mgmt", "acct", "comm", "tech"];
 const SKILL_LABELS = {
   mgmt: "Management",
@@ -183,21 +185,27 @@ function calculateSimilarity(a, b) {
  * Find best matching HR blurp entry from JSON based on feedback text
  * Returns the entry with highest similarity score above threshold
  */
-function findBestMatchingEntry(feedbackText) {
+export function findBestMatchingEntry(feedbackText, langCode, { threshold = SIMILARITY_THRESHOLD } = {}) {
   if (!feedbackText) return null;
 
   let bestMatch = null;
-  let bestScore = SIMILARITY_THRESHOLD;
+  let bestScore = threshold;
 
-  // Check all entries to find best match (don't stop at first)
   for (const entry of hrBlurpData) {
-    // Try to match against English feedback (primary language)
-    const originalFeedback = entry.en?.originalFeedback || "";
-    const score = calculateSimilarity(feedbackText, originalFeedback);
+    // If a specific language is requested and the entry has that language, try it first
+    if (langCode && langCode !== "en" && entry[langCode]?.originalFeedback) {
+      const localScore = calculateSimilarity(feedbackText, entry[langCode].originalFeedback);
+      if (localScore > bestScore) {
+        bestScore = localScore;
+        bestMatch = entry;
+      }
+    }
 
-    // Update best match if this score is higher
-    if (score > bestScore) {
-      bestScore = score;
+    // Always also try English
+    const enFeedback = entry.en?.originalFeedback || "";
+    const enScore = calculateSimilarity(feedbackText, enFeedback);
+    if (enScore > bestScore) {
+      bestScore = enScore;
       bestMatch = entry;
     }
   }
@@ -360,6 +368,43 @@ function createFeedbackSectionHTML(feedbackText) {
 }
 
 /**
+ * Create HTML showing the matched English blurb for verification
+ */
+function createMatchedBlurbHTML(matchedEntry) {
+  const enFeedback = matchedEntry?.en?.originalFeedback;
+  if (!enFeedback) return "";
+
+  return `
+    <div class="scx-hr-blurp-feedback-section">
+      <div class="scx-hr-blurp-feedback-label">${escapeHtml(t("matchedEnglishBlurb"))}</div>
+      <div class="scx-hr-blurp-feedback-text" style="font-style: italic; opacity: 0.8;">${escapeHtml(enFeedback)}</div>
+    </div>
+  `;
+}
+
+/**
+ * Create HTML for translation unavailable hint
+ */
+function createTranslationUnavailableHTML() {
+  return `
+    <div class="scx-hr-blurp-feedback-section">
+      <div class="scx-hr-blurp-translation-unavailable">${escapeHtml(t("translationUnavailable"))}</div>
+    </div>
+  `;
+}
+
+/**
+ * Create HTML for translation loading state
+ */
+function createTranslatingHTML() {
+  return `
+    <div class="scx-hr-blurp-feedback-section">
+      <div class="scx-hr-blurp-translating">${escapeHtml(t("translatingFeedback"))}</div>
+    </div>
+  `;
+}
+
+/**
  * Create HTML for the HR skills section
  */
 function createSkillsSectionHTML(matchedEntry) {
@@ -418,7 +463,7 @@ function createNavigationMessageHTML() {
 /**
  * Update the executive helper panel in the sidebar
  */
-export function updateExecutivePanel() {
+export async function updateExecutivePanel() {
   // Get the section content container
   const content = getSectionContent(SECTION_ID);
   if (!content) return;
@@ -438,13 +483,36 @@ export function updateExecutivePanel() {
     return;
   }
 
+  const lang = getLang();
+
   // Try to find HR blurp match if we have feedback
   let matchedEntry = null;
-  let hasHRFeedback = false;
 
   if (feedbackText) {
-    matchedEntry = findBestMatchingEntry(feedbackText);
-    hasHRFeedback = matchedEntry !== null;
+    // First try matching against available language variants in hr_blurp.json
+    matchedEntry = findBestMatchingEntry(feedbackText, lang);
+
+    // If no match and language is not English, translate and retry
+    if (!matchedEntry && lang !== "en") {
+      // Show loading state with skills breakdown
+      let loadingHtml = "";
+      if (executiveSkills) {
+        loadingHtml += createSkillsBreakdownSectionHTML(executiveSkills, trainingSkills);
+      }
+      loadingHtml += createFeedbackSectionHTML(feedbackText);
+      loadingHtml += createTranslatingHTML();
+      content.innerHTML = loadingHtml;
+
+      const translatedText = await translateToEnglish(feedbackText, lang);
+
+      if (translatedText) {
+        matchedEntry = findBestMatchingEntry(translatedText, "en", { threshold: TRANSLATED_SIMILARITY_THRESHOLD });
+      }
+
+      // Re-check content is still valid (user may have navigated away)
+      const currentContent = getSectionContent(SECTION_ID);
+      if (!currentContent || currentContent !== content) return;
+    }
   }
 
   // Build HTML for the panel
@@ -455,13 +523,20 @@ export function updateExecutivePanel() {
     html += createSkillsBreakdownSectionHTML(executiveSkills, trainingSkills);
   }
 
-  // Show HR assessment only if we have feedback and matched entry
-  if (hasHRFeedback && feedbackText && matchedEntry) {
+  // Show HR assessment if we have feedback
+  if (matchedEntry && feedbackText) {
     html += createFeedbackSectionHTML(feedbackText);
+    if (lang !== "en") {
+      html += createMatchedBlurbHTML(matchedEntry);
+    }
     html += createSkillsSectionHTML(matchedEntry);
     html += createFooterHTML(matchedEntry);
+  } else if (feedbackText && lang !== "en") {
+    // Non-English, no match found — translation failed or no match after translation
+    html += createFeedbackSectionHTML(feedbackText);
+    html += createTranslationUnavailableHTML();
   } else if (feedbackText) {
-    // Show feedback even if no match found
+    // English, no match found
     html += createFeedbackSectionHTML(feedbackText);
   }
 

--- a/src/translate.js
+++ b/src/translate.js
@@ -1,0 +1,48 @@
+// translate.js
+// Translates text to English via Lingva Translate API with fallback instances
+
+const LINGVA_PRIMARY = "lingva.ml";
+const LINGVA_FALLBACK = "lingva.thedaviddelta.com";
+const TRANSLATE_TIMEOUT_MS = 5000;
+
+// Map i18n language codes to Lingva API codes
+const LANG_CODE_MAP = {
+  zh_cn: "zh",
+  zh_tw: "zh",
+};
+
+/**
+ * Translate text to English using Lingva Translate.
+ * Tries primary instance first, falls back to secondary.
+ * @param {string} text - Text to translate
+ * @param {string} langCode - Source language code from i18n (e.g. "de", "zh_cn")
+ * @returns {Promise<string|null>} Translated English text, or null if translation fails or langCode is "en"
+ */
+export async function translateToEnglish(text, langCode) {
+  if (langCode === "en") return null;
+
+  const lingvaLang = LANG_CODE_MAP[langCode] || langCode;
+  const encodedText = encodeURIComponent(text);
+
+  const instances = [LINGVA_PRIMARY, LINGVA_FALLBACK];
+
+  for (const instance of instances) {
+    try {
+      const url = `https://${instance}/api/v1/${lingvaLang}/en/${encodedText}`;
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), TRANSLATE_TIMEOUT_MS);
+
+      const res = await fetch(url, { signal: controller.signal, cache: "no-store" });
+      clearTimeout(timeoutId);
+
+      if (!res.ok) continue;
+
+      const data = await res.json();
+      if (data.translation) return data.translation;
+    } catch {
+      // Network error or timeout — try next instance
+    }
+  }
+
+  return null;
+}

--- a/src/translations/cs.js
+++ b/src/translations/cs.js
@@ -192,4 +192,6 @@ export default {
   xpOperating: "V provozu",
   xpProspecting: "Průzkum",
   xpIdle: "Nečinné",
+  translationUnavailable: "Překladová služba nedostupná — hodnocení HR přeskočeno",
+  translatingFeedback: "Překládání zpětné vazby...",
 };

--- a/src/translations/de.js
+++ b/src/translations/de.js
@@ -194,4 +194,7 @@ export default {
   xpOperating: "In Betrieb",
   xpProspecting: "Erkundung",
   xpIdle: "Inaktiv",
+  translationUnavailable: "Übersetzungsdienst nicht verfügbar — HR-Bewertung übersprungen",
+  translatingFeedback: "Feedback wird übersetzt...",
+  matchedEnglishBlurb: "Zugeordneter englischer Blurb",
 };

--- a/src/translations/en.js
+++ b/src/translations/en.js
@@ -192,4 +192,7 @@ export default {
   xpOperating: "Operating",
   xpProspecting: "Prospecting",
   xpIdle: "Idle",
+  translationUnavailable: "Translation service unavailable — HR assessment skipped",
+  translatingFeedback: "Translating feedback...",
+  matchedEnglishBlurb: "Matched English Blurb",
 };

--- a/src/translations/es.js
+++ b/src/translations/es.js
@@ -193,4 +193,6 @@ export default {
   xpOperating: "Operando",
   xpProspecting: "Prospección",
   xpIdle: "Inactivo",
+  translationUnavailable: "Servicio de traducción no disponible — evaluación de RRHH omitida",
+  translatingFeedback: "Traduciendo feedback...",
 };

--- a/src/translations/fr.js
+++ b/src/translations/fr.js
@@ -194,4 +194,6 @@ export default {
   xpOperating: "En activité",
   xpProspecting: "Prospection",
   xpIdle: "Inactif",
+  translationUnavailable: "Service de traduction indisponible — évaluation RH ignorée",
+  translatingFeedback: "Traduction du feedback...",
 };

--- a/src/translations/it.js
+++ b/src/translations/it.js
@@ -194,4 +194,6 @@ export default {
   xpOperating: "In funzione",
   xpProspecting: "Prospezione",
   xpIdle: "Inattivo",
+  translationUnavailable: "Servizio di traduzione non disponibile — valutazione HR saltata",
+  translatingFeedback: "Traduzione del feedback...",
 };

--- a/src/translations/ja.js
+++ b/src/translations/ja.js
@@ -192,4 +192,6 @@ export default {
   xpOperating: "稼働中",
   xpProspecting: "探査中",
   xpIdle: "待機中",
+  translationUnavailable: "翻訳サービスが利用できません — HR評価をスキップしました",
+  translatingFeedback: "フィードバックを翻訳中...",
 };

--- a/src/translations/pl.js
+++ b/src/translations/pl.js
@@ -192,4 +192,6 @@ export default {
   xpOperating: "Działające",
   xpProspecting: "Poszukiwanie",
   xpIdle: "Bezczynne",
+  translationUnavailable: "Usługa tłumaczenia niedostępna — ocena HR pominięta",
+  translatingFeedback: "Tłumaczenie opinii...",
 };

--- a/src/translations/pt.js
+++ b/src/translations/pt.js
@@ -193,4 +193,6 @@ export default {
   xpOperating: "Operando",
   xpProspecting: "Prospecção",
   xpIdle: "Inativo",
+  translationUnavailable: "Serviço de tradução indisponível — avaliação de RH ignorada",
+  translatingFeedback: "Traduzindo feedback...",
 };

--- a/src/translations/tr.js
+++ b/src/translations/tr.js
@@ -192,4 +192,6 @@ export default {
   xpOperating: "Çalışıyor",
   xpProspecting: "Arama",
   xpIdle: "Boşta",
+  translationUnavailable: "Çeviri hizmeti kullanılamıyor — İK değerlendirmesi atlandı",
+  translatingFeedback: "Geri bildirim çevriliyor...",
 };

--- a/src/translations/zh_cn.js
+++ b/src/translations/zh_cn.js
@@ -192,4 +192,6 @@ export default {
   xpOperating: "运营中",
   xpProspecting: "探矿中",
   xpIdle: "空闲",
+  translationUnavailable: "翻译服务不可用 — 已跳过HR评估",
+  translatingFeedback: "正在翻译反馈...",
 };

--- a/src/translations/zh_tw.js
+++ b/src/translations/zh_tw.js
@@ -192,4 +192,6 @@ export default {
   xpOperating: "運營中",
   xpProspecting: "探礦中",
   xpIdle: "閒置",
+  translationUnavailable: "翻譯服務不可用 — 已跳過HR評估",
+  translatingFeedback: "正在翻譯反饋...",
 };

--- a/tests/executive_ui.test.js
+++ b/tests/executive_ui.test.js
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock dependencies
+vi.mock("string-similarity-js", () => ({
+  stringSimilarity: vi.fn((a, b) => {
+    // Simple mock: return 1.0 if strings match, 0.0 otherwise
+    return a.toLowerCase().trim() === b.toLowerCase().trim() ? 1.0 : 0.0;
+  }),
+}));
+
+vi.mock("../src/resources/hr_blurp.json", () => ({
+  default: [
+    {
+      id: 1,
+      en: { originalFeedback: "English feedback text about combs" },
+      tr: { originalFeedback: "Türkçe geri bildirim metni taraklar hakkında" },
+      skills: { mgmt: 0.43, acct: 0.57, comm: 0.43, tech: 0.64, avgSkill: 0.52 },
+    },
+    {
+      id: 2,
+      en: { originalFeedback: "English feedback about coffee and sugar" },
+      skills: { mgmt: 0.54, acct: 0.46, comm: 0.54, tech: 0.62, avgSkill: 0.54 },
+    },
+  ],
+}));
+
+vi.mock("../src/i18n.js", () => ({
+  t: (key) => key,
+  getLang: () => "en",
+}));
+
+vi.mock("../src/sidebar.js", () => ({
+  getSectionContent: () => null,
+}));
+
+vi.mock("../src/utils.js", () => ({
+  escapeHtml: (s) => s,
+}));
+
+vi.mock("../src/translate.js", () => ({
+  translateToEnglish: vi.fn(),
+}));
+
+// Import after mocks
+import { findBestMatchingEntry } from "../src/executive_ui.js";
+
+describe("findBestMatchingEntry", () => {
+  it("matches English feedback against en entries", () => {
+    const result = findBestMatchingEntry("English feedback text about combs");
+    expect(result).not.toBeNull();
+    expect(result.id).toBe(1);
+  });
+
+  it("matches Turkish feedback against tr entries when langCode is tr", () => {
+    const result = findBestMatchingEntry(
+      "Türkçe geri bildirim metni taraklar hakkında",
+      "tr",
+    );
+    expect(result).not.toBeNull();
+    expect(result.id).toBe(1);
+  });
+
+  it("falls back to English when langCode entries not found", () => {
+    const result = findBestMatchingEntry("English feedback about coffee and sugar", "de");
+    expect(result).not.toBeNull();
+    expect(result.id).toBe(2);
+  });
+
+  it("returns null when no match found", () => {
+    const result = findBestMatchingEntry("completely unrelated text");
+    expect(result).toBeNull();
+  });
+
+  it("returns null for empty text", () => {
+    const result = findBestMatchingEntry("");
+    expect(result).toBeNull();
+  });
+});

--- a/tests/translate.test.js
+++ b/tests/translate.test.js
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const LINGVA_PRIMARY = "lingva.ml";
+const LINGVA_FALLBACK = "lingva.thedaviddelta.com";
+
+import { translateToEnglish } from "../src/translate.js";
+
+describe("translateToEnglish", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns null for English language code", async () => {
+    const result = await translateToEnglish("some text", "en");
+    expect(result).toBeNull();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("translates text via primary Lingva instance", async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ translation: "translated text" }),
+    });
+
+    const result = await translateToEnglish("deutscher text", "de");
+    expect(result).toBe("translated text");
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch.mock.calls[0][0]).toContain(LINGVA_PRIMARY);
+    expect(fetch.mock.calls[0][0]).toContain("/de/en/");
+  });
+
+  it("falls back to secondary instance on primary failure", async () => {
+    fetch.mockRejectedValueOnce(new Error("network error"));
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ translation: "translated text" }),
+    });
+
+    const result = await translateToEnglish("deutscher text", "de");
+    expect(result).toBe("translated text");
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch.mock.calls[1][0]).toContain(LINGVA_FALLBACK);
+  });
+
+  it("falls back on non-OK HTTP status from primary", async () => {
+    fetch.mockResolvedValueOnce({ ok: false, status: 500 });
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ translation: "translated text" }),
+    });
+
+    const result = await translateToEnglish("deutscher text", "de");
+    expect(result).toBe("translated text");
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns null when both instances fail", async () => {
+    fetch.mockRejectedValueOnce(new Error("network error"));
+    fetch.mockRejectedValueOnce(new Error("network error"));
+
+    const result = await translateToEnglish("deutscher text", "de");
+    expect(result).toBeNull();
+  });
+
+  it("maps zh_cn to zh for Lingva API", async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ translation: "translated" }),
+    });
+
+    await translateToEnglish("中文文本", "zh_cn");
+    expect(fetch.mock.calls[0][0]).toContain("/zh/en/");
+  });
+
+  it("maps zh_tw to zh for Lingva API", async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ translation: "translated" }),
+    });
+
+    await translateToEnglish("中文文本", "zh_tw");
+    expect(fetch.mock.calls[0][0]).toContain("/zh/en/");
+  });
+
+  it("encodes text in URL", async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ translation: "translated" }),
+    });
+
+    await translateToEnglish("text with spaces & symbols", "de");
+    expect(fetch.mock.calls[0][0]).toContain(encodeURIComponent("text with spaces & symbols"));
+  });
+});


### PR DESCRIPTION
  ## Summary                                                                                                                                                                          
                                                            
  The Executive Recruitment HR feedback analysis previously only worked when the game language was set to English. The HR blurb text is generated once in the player's account        
  language and stored as a fixed string — there is no way to retrieve the English original.
                                                                                                                                                                                      
  This PR adds automatic translation of non-English HR blurbs to English via the [Lingva Translate](https://github.com/thedaviddelta/lingva-translate) API before matching against the
   known blurb database.

<img width="1056" height="762" alt="Bildschirmfoto 2026-03-27 um 10 36 24" src="https://github.com/user-attachments/assets/51ab1567-816b-4234-a122-0c97c8de3599" />
                                                                                                                                                                                      
  ## How it works                                           

  1. Extract HR feedback text from the page (existing, works in any language)                                                                                                         
  2. Try matching against available language variants in `hr_blurp.json` (e.g. Turkish entries)
  3. If no match and language is not English → translate via Lingva Translate API                                                                                                     
  4. Match translated text against English entries with a lower similarity threshold (0.55 vs 0.7) to account for back-translation variance
  5. Display the matched English blurb for verification                                                                                                                               
   
  ## Features                                                                                                                                                                         
                                                            
  - **Lingva Translate integration** with fallback instance (`lingva.ml` → `lingva.thedaviddelta.com`)                                                                                
  - **5-second timeout** per instance via AbortController
  - **Graceful degradation** — if translation fails, skills breakdown still renders with a "Translation unavailable" hint                                                             
  - **Loading state** — shows "Translating feedback..." while the API call is in progress
  - **Matched blurb display** — shows the matched English original below the extracted feedback for non-English users                                                                 
  - **Multi-language matching** — `findBestMatchingEntry` now checks all available language variants in `hr_blurp.json` before resorting to translation
  - **Translation keys** added for all 12 supported languages                                                                                                                         
                                                            
  ## Changes                                                                                                                                                                          
                                                            
  - **New:** `src/translate.js` — Lingva API module with fallback
  - **New:** `tests/translate.test.js` — 8 tests
  - **New:** `tests/executive_ui.test.js` — 5 tests
  - **Modified:** `src/executive_ui.js` — async panel update, multi-language matching, translation flow                                                                               
  - **Modified:** `public/manifest.json` — added host permissions for Lingva API domains
  - **Modified:** 12 translation files — new keys for translation states                                                                                                              
                                                            
  ## Test plan                                                                                                                                                                        
                                                            
  - [x] All 202 tests passing
  - [x] Build succeeds
  - [x] Tested with German game language — HR blurb correctly translated and matched
  - [x] Verified graceful degradation when API is unreachable